### PR TITLE
Compatibilidade: Listar disciplinas e turmas compativel com o IFSC

### DIFF
--- a/examples/get-subjects.js
+++ b/examples/get-subjects.js
@@ -6,28 +6,37 @@ const sigaa = new Sigaa({
 let result = sigaa.search.subject()
 
 async function main() {
-    try {
-      // get Campus List to find out your Campus' index. 
-      const campusList = await result.getCampusList();
-      
-      const campus = campusList[78];
-      const jsonsify = true;
-      const year = 2023;
-      const period = 1;
-      
-      const unb_fga_subjects = await result.search(jsonsify, campus, year, period);
+  try {
+    // get Campus List to find out your Campus' index. 
+    const campusList = await result.getCampusList();
 
-      // get all subjects from your search.
-      console.log('Lista de campus');
-      console.log(unb_fga_subjects);
+    const campus = campusList[4];
+    const jsonsify = true;
+    const year = 2023;
+    const period = 1;
 
-      // get all classes/teams from the first subject
-      console.log(unb_fga_subjects[1].teams);
-    }
-    catch (err) {
-      console.log(err);
-      
-    }
+    const unb_fga_subjects = await result.search(jsonsify, campus, year, period);
+
+    // get all subjects from your search.
+    console.log('Lista de campus');
+    unb_fga_subjects.map(subject => {
+      console.log(`\n${subject.id} - ${subject.name}`);
+      console.log(`Turmas:`);
+      subject.teams.map(team => {
+        console.log(`  Código: ${team.id}`);
+        console.log(`  Docente: ${team.teacher}`);
+        console.log(`  Local: ${team.location}`);
+        if (team.schedule) {
+          console.log(`  Horário: ${team.schedule}`);
+        }
+        console.log(``);
+      });
+    })
+  }
+  catch (err) {
+    console.log(err);
+
+  }
 }
 
 main()

--- a/src/search/sigaa-common-structures.ts
+++ b/src/search/sigaa-common-structures.ts
@@ -2,10 +2,6 @@
  * @category Public
  */
 export interface Campus {
-    name: string;
-    value: string;
+  name: string;
+  value: string;
 }
-
-
-
-  

--- a/src/search/sigaa-search.ts
+++ b/src/search/sigaa-search.ts
@@ -1,18 +1,28 @@
 import { Parser } from '@helpers/sigaa-parser';
 import { HTTP } from '@session/sigaa-http';
 import { SigaaSearchTeacher } from './teacher/sigaa-search-teacher';
-import { SigaaSearchSubject } from './subject/sigaa-search-subject';
+import { Session } from '@session/sigaa-session';
+import { SigaaSearchSubjectIFSC } from './subject/IFSC/sigaa-search-subject-IFSC';
+import { SigaaSearchSubjectUNB } from './subject/UNB/sigaa-search-subject-UNB';
 
-/**
- * @category Public
- */
+export type SigaaSearchSubject = SigaaSearchSubjectIFSC | SigaaSearchSubjectUNB;
 export class SigaaSearch {
-  constructor(private http: HTTP, private parser: Parser) {}
+  constructor(
+    private http: HTTP,
+    private parser: Parser,
+    private session: Session
+  ) {}
 
   teacher(): SigaaSearchTeacher {
     return new SigaaSearchTeacher(this.http, this.parser);
   }
   subject(): SigaaSearchSubject {
-    return new SigaaSearchSubject(this.http, this.parser);
+    const institution = this.session.institution;
+    const SigaaSearchSubject = {
+      IFSC: SigaaSearchSubjectIFSC,
+      UNB: SigaaSearchSubjectUNB,
+      UFPB: SigaaSearchSubjectIFSC
+    };
+    return new SigaaSearchSubject[institution](this.http, this.parser);
   }
 }

--- a/src/search/subject/IFSC/sigaa-search-subject-IFSC.ts
+++ b/src/search/subject/IFSC/sigaa-search-subject-IFSC.ts
@@ -1,0 +1,231 @@
+import { Parser } from '@helpers/sigaa-parser';
+import { HTTP } from '@session/sigaa-http';
+import { Page } from '@session/sigaa-page';
+import { URL } from 'url';
+import { Campus } from '../../sigaa-common-structures';
+import {
+  SigaaSearchSubjectResultIFSC,
+  SigaaSearchTeamsResultIFSC,
+  SubjectResultIFSC,
+  TeamsResultIFSC
+} from './sigaa-search-subject-result-IFSC';
+
+/**
+ * @category Public
+ */
+export class SigaaSearchSubjectIFSC {
+  page: Page | null = null;
+
+  constructor(private http: HTTP, private parser: Parser) {}
+
+  async loadSearchPage(): Promise<void> {
+    if (!this.page) {
+      this.page = await this.http.get('/sigaa/public/turmas/listar.jsf');
+    }
+  }
+
+  async getCampusList(): Promise<Campus[]> {
+    await this.loadSearchPage();
+    const page = this.page as Page;
+    const campusOptionElements = page
+      .$('select#formTurma\\:inputDepto > option')
+      .toArray();
+    const list = [];
+    for (const campusOptionElement of campusOptionElements) {
+      list.push({
+        name: this.parser.removeTagsHtml(page.$(campusOptionElement).html()),
+        value: this.parser.removeTagsHtml(page.$(campusOptionElement).val())
+      });
+    }
+    return list;
+  }
+
+  async search(
+    jsonsify?: boolean,
+    campus?: Campus,
+    year?: number,
+    period?: number
+  ): Promise<SubjectResultIFSC[]> {
+    await this.loadSearchPage();
+    const page = this.page as Page;
+    let campusValue, in_json: boolean;
+    if (!campus) {
+      campusValue = '0';
+    } else {
+      campusValue = campus.value;
+    }
+    if (!jsonsify) {
+      in_json = false;
+    } else {
+      in_json = jsonsify;
+    }
+    if (!period) {
+      period = 1;
+    } else if (Number.isInteger(period) && 1 > period && period > 4) {
+      throw new Error('SIGAA: Invalid period value.');
+    }
+    if (!year) {
+      const now = new Date();
+      year = now.getFullYear();
+    } else if (Number.isInteger(year) && year < 1950 && year > 2100) {
+      throw new Error('SIGAA: Invalid year value.');
+    }
+
+    const formElement = page.$('form[name="formTurma"]');
+    const action = formElement.attr('action');
+    if (!action)
+      throw new Error('SIGAA: Form with action at Subject search page.');
+
+    const url = new URL(action, page.url);
+    const postValues: Record<string, string> = {};
+    const inputs = formElement
+      .find("input[name]:not([type='submit'])")
+      .toArray();
+    for (const input of inputs) {
+      const name = page.$(input).attr('name');
+      if (name) postValues[name] = page.$(input).val();
+    }
+    postValues['formTurma:inputNivel'] = '';
+    postValues['formTurma:inputDepto'] = campusValue;
+    postValues['formTurma:inputAno'] = year.toString();
+    postValues['formTurma:inputPeriodo'] = period.toString();
+
+    const searchButtonNameAttr = page.$('input[value="Buscar"]').attr('name');
+    if (!searchButtonNameAttr)
+      throw new Error('SIGAA: Search button not found.');
+
+    postValues[searchButtonNameAttr] = 'Buscar';
+
+    const pageResults = await this.http.post(url.href, postValues);
+    return this.parseSearchResults(pageResults, in_json);
+  }
+
+  private async parseSearchResults(
+    page: Page,
+    in_json: boolean
+  ): Promise<SubjectResultIFSC[]> {
+    if (
+      page.bodyDecoded.includes(
+        'Não foram encontrados resultados para a busca com estes parâmetros.'
+      )
+    )
+      return [];
+    const rowHeaderElements = page
+      .$('table.listagem > thead > tr > th')
+      .toArray();
+    const rowElements = page.$('table.listagem > tbody > tr[class]').toArray();
+
+    if (in_json) {
+      return this.jsonfySubjectResult(page, rowHeaderElements, rowElements);
+    } else {
+      return this.objectfySubjectResult(page, rowHeaderElements, rowElements);
+    }
+  }
+
+  private jsonfySubjectResult(
+    page: Page,
+    rowHeaderElements: cheerio.Element[],
+    rowElements: cheerio.Element[]
+  ): SubjectResultIFSC[] {
+    const results = [];
+    for (const rowElement of rowElements) {
+      if (page.$(rowElement).hasClass('agrupador')) {
+        results.push(this.parseSubjectSearchResults(page, rowElement));
+      } else if (
+        page.$(rowElement).hasClass('linhaPar') ||
+        page.$(rowElement).hasClass('linhaImpar')
+      ) {
+        results[results.length - 1].teams.push(
+          this.parseTeamsSearchResults(page, rowHeaderElements, rowElement)
+        );
+      } else {
+        continue;
+      }
+    }
+    return results;
+  }
+
+  private async objectfySubjectResult(
+    page: Page,
+    rowHeaderElements: cheerio.Element[],
+    rowElements: cheerio.Element[]
+  ): Promise<SubjectResultIFSC[]> {
+    const results: SubjectResultIFSC[] = [];
+    for (const rowElement of rowElements) {
+      if (page.$(rowElement).hasClass('agrupador')) {
+        results.push(
+          new SigaaSearchSubjectResultIFSC(
+            this.http,
+            this.parser,
+            this.parseSubjectSearchResults(page, rowElement)
+          )
+        );
+      } else if (
+        page.$(rowElement).hasClass('linhaPar') ||
+        page.$(rowElement).hasClass('linhaImpar')
+      ) {
+        results[results.length - 1].teams.push(
+          new SigaaSearchTeamsResultIFSC(
+            this.http,
+            this.parser,
+            this.parseTeamsSearchResults(page, rowHeaderElements, rowElement)
+          )
+        );
+      } else {
+        continue;
+      }
+    }
+    return results;
+  }
+  private parseSubjectSearchResults(
+    page: Page,
+    rowElement: cheerio.Element
+  ): SubjectResultIFSC {
+    const id_name: string[] = this.parser
+      .removeTagsHtml(page.$(rowElement).find('span.tituloDisciplina').html())
+      .split(' - ');
+    const id = id_name[0];
+    const name = id_name[1];
+    const teams: TeamsResultIFSC[] = [];
+    return {
+      id,
+      name,
+      teams
+    };
+  }
+
+  private parseTeamsSearchResults(
+    page: Page,
+    rowHeaderElements: cheerio.Element[],
+    rowElement: cheerio.Element
+  ) {
+    let id: number | undefined;
+    let teacher: string | undefined;
+    let location: string | undefined;
+    for (let i = 0; i < rowHeaderElements.length; i++) {
+      const columnHeader = page.$(rowHeaderElements[i]).text();
+      const columnValue = page.$(rowElement).find('td').eq(i).text();
+      switch (columnHeader) {
+        case 'Código':
+          id = Number.parseInt(columnValue);
+          break;
+        case 'Docente':
+          teacher = columnValue;
+          break;
+        case 'Local':
+          location = columnValue;
+      }
+    }
+    if (id === undefined) throw new Error('SIGAA: Could not parse team id.');
+    if (teacher === undefined)
+      throw new Error('SIGAA: Could not parse teacher.');
+    if (location === undefined)
+      throw new Error('SIGAA: Could not parse location.');
+
+    return {
+      id,
+      teacher,
+      location
+    };
+  }
+}

--- a/src/search/subject/IFSC/sigaa-search-subject-result-IFSC.ts
+++ b/src/search/subject/IFSC/sigaa-search-subject-result-IFSC.ts
@@ -1,140 +1,116 @@
 import { Parser } from '@helpers/sigaa-parser';
-import { HTTP, ProgressCallback } from '@session/sigaa-http';
-import { Sigaa } from 'src/sigaa-main';
-import { URL } from 'url';
-
+import { HTTP } from '@session/sigaa-http';
 
 /**
  * @category Internal
  */
-export interface TeamsResultData {
+export interface TeamsResultDataIFSC {
   id: number;
   teacher: string;
-  schedule: string;
   location: string;
 }
 
 /**
  * @category Public
  */
-export interface TeamsResult {
+export interface TeamsResultIFSC {
   readonly id: number;
   readonly teacher: string;
-  readonly schedule: string;
   readonly location: string;
 }
 
 /**
  * @category Internal
  */
-export interface SubjectResultData {
+export interface SubjectResultDataIFSC {
   id: string;
   name: string;
-  teams: TeamsResultData[]
+  teams: TeamsResultDataIFSC[];
 }
 
 /**
  * @category Public
  */
-export interface SubjectResult {
+export interface SubjectResultIFSC {
   readonly id: string;
   readonly name: string;
-  readonly teams: TeamsResult[]
+  readonly teams: TeamsResultIFSC[];
 }
-
-
 
 /**
  * @category Internal
  */
-export class SigaaSearchTeamsResult implements TeamsResult {
+export class SigaaSearchTeamsResultIFSC implements TeamsResultIFSC {
   private _id: number;
   private _teacher: string;
-  private _schedule: string;
   private _location: string;
 
   constructor(
     private _http: HTTP,
     private _parser: Parser,
-    options: TeamsResultData
-    
+    options: TeamsResultDataIFSC
   ) {
     this._id = options.id;
     this._teacher = options.teacher;
-    this._schedule = options.schedule;
     this._location = options.location;
   }
 
-  
-  public get id() : number {
+  public get id(): number {
     return this._id;
   }
-  
-  public get teacher() : string {
+
+  public get teacher(): string {
     return this._teacher;
   }
-  
-  public get schedule() : string {
-    return this._schedule;
-  }
 
-  public get location() : string {
+  public get location(): string {
     return this._location;
   }
-  
-  
-  public get http() : HTTP {
+
+  public get http(): HTTP {
     return this._http;
   }
-  
 
-  public get parser() : Parser {
+  public get parser(): Parser {
     return this._parser;
   }
-  
-  
 }
 
 /**
  * @category Internal
  */
-export class SigaaSearchSubjectResult implements SubjectResult {
-  private _id : string;
+export class SigaaSearchSubjectResultIFSC implements SubjectResultIFSC {
+  private _id: string;
   private _name: string;
-  private _teams: TeamsResultData[];
+  private _teams: TeamsResultDataIFSC[];
 
   constructor(
     private _http: HTTP,
     private _parser: Parser,
-    options: SubjectResultData
+    options: SubjectResultDataIFSC
   ) {
     this._id = options.id;
     this._name = options.name;
     this._teams = options.teams;
   }
 
-  
-  public get id() : string {
+  public get id(): string {
     return this._id;
   }
-  
-  public get name() : string {
+
+  public get name(): string {
     return this._name;
   }
-  
-  public get teams() : TeamsResult[] {
+
+  public get teams(): TeamsResultIFSC[] {
     return this._teams;
   }
 
-  
-  public get http() : HTTP {
+  public get http(): HTTP {
     return this._http;
   }
-  
-  
-  public get parser() : Parser {
+
+  public get parser(): Parser {
     return this._parser;
   }
-  
 }
-

--- a/src/search/subject/UNB/sigaa-search-subject-UNB.ts
+++ b/src/search/subject/UNB/sigaa-search-subject-UNB.ts
@@ -3,28 +3,24 @@ import { HTTP } from '@session/sigaa-http';
 import { Page } from '@session/sigaa-page';
 import { URL } from 'url';
 import {
-  SigaaSearchTeamsResult,
-  SigaaSearchSubjectResult,
-  SubjectResult,
-  TeamsResult
-} from './sigaa-search-subject-result';
-import {
-  Campus
-} from '../sigaa-common-structures';
+  SigaaSearchTeamsResultUNB,
+  SigaaSearchSubjectResultUNB,
+  SubjectResultUNB,
+  TeamsResultUNB
+} from './sigaa-search-subject-result-UNB';
+import { Campus } from '@search/sigaa-common-structures';
 
 /**
  * @category Public
  */
-export class SigaaSearchSubject {
+export class SigaaSearchSubjectUNB {
   page: Page | null = null;
 
   constructor(private http: HTTP, private parser: Parser) {}
 
   async loadSearchPage(): Promise<void> {
     if (!this.page) {
-      this.page = await this.http.get(
-        '/sigaa/public/turmas/listar.jsf'
-      );
+      this.page = await this.http.get('/sigaa/public/turmas/listar.jsf');
     }
   }
 
@@ -44,7 +40,12 @@ export class SigaaSearchSubject {
     return list;
   }
 
-  async search(jsonsify?:boolean, campus?: Campus, year?:number, period?:number): Promise<SubjectResult[]> {
+  async search(
+    jsonsify?: boolean,
+    campus?: Campus,
+    year?: number,
+    period?: number
+  ): Promise<SubjectResultUNB[]> {
     await this.loadSearchPage();
     const page = this.page as Page;
     let campusValue, in_json: boolean;
@@ -60,16 +61,14 @@ export class SigaaSearchSubject {
     }
     if (!period) {
       period = 1;
-    }
-    else if (Number.isInteger(period) && 1 > period && period > 4) {
-      throw new Error("SIGAA: Invalid period value.");
+    } else if (Number.isInteger(period) && 1 > period && period > 4) {
+      throw new Error('SIGAA: Invalid period value.');
     }
     if (!year) {
-      const now = new Date()
+      const now = new Date();
       year = now.getFullYear();
-    }
-    else if (Number.isInteger(year) && year < 1950 && year > 2100) {
-      throw new Error("SIGAA: Invalid year value.");
+    } else if (Number.isInteger(year) && year < 1950 && year > 2100) {
+      throw new Error('SIGAA: Invalid year value.');
     }
 
     const formElement = page.$('form[name="formTurma"]');
@@ -86,23 +85,32 @@ export class SigaaSearchSubject {
       const name = page.$(input).attr('name');
       if (name) postValues[name] = page.$(input).val();
     }
-    postValues['formTurma:inputNivel'] = "";
+    postValues['formTurma:inputNivel'] = '';
     postValues['formTurma:inputDepto'] = campusValue;
     postValues['formTurma:inputAno'] = year.toString();
     postValues['formTurma:inputPeriodo'] = period.toString();
-    postValues['formTurma:j_id_jsp_1370969402_11'] = 'Buscar';
+
+    const searchButtonNameAttr = page.$('input[value="Buscar"]').attr('name');
+    if (!searchButtonNameAttr)
+      throw new Error('SIGAA: Search button not found.');
+
+    postValues[searchButtonNameAttr] = 'Buscar';
+
     return this.http
       .post(url.href, postValues)
       .then((page) => this.parseSearchResults(page, in_json));
   }
 
-  private async parseSubjectSearchResults(page: Page, rowElement: cheerio.Element): Promise<SubjectResult> {
-    const id_name:string[] = this.parser.removeTagsHtml(
-      page.$(rowElement).find('span.tituloDisciplina').html()
-    ).split("-");
+  private async parseSubjectSearchResults(
+    page: Page,
+    rowElement: cheerio.Element
+  ): Promise<SubjectResultUNB> {
+    const id_name: string[] = this.parser
+      .removeTagsHtml(page.$(rowElement).find('span.tituloDisciplina').html())
+      .split(' - ');
     const id = id_name[0];
     const name = id_name[1];
-    const teams:any[] = []
+    const teams: TeamsResultUNB[] = [];
     return {
       id,
       name,
@@ -110,10 +118,13 @@ export class SigaaSearchSubject {
     };
   }
 
-  private async parseTeamsSearchResults(page: Page, rowElement: cheerio.Element): Promise<TeamsResult> {
-    const id: number = parseInt(this.parser.removeTagsHtml(
-      page.$(rowElement).find('td.turma').html()
-    ));
+  private async parseTeamsSearchResults(
+    page: Page,
+    rowElement: cheerio.Element
+  ): Promise<TeamsResultUNB> {
+    const id: number = parseInt(
+      this.parser.removeTagsHtml(page.$(rowElement).find('td.turma').html())
+    );
 
     const teacher: string = this.parser.removeTagsHtml(
       page.$(rowElement).find('td.nome').html()
@@ -131,47 +142,65 @@ export class SigaaSearchSubject {
       schedule,
       location
     };
-
-    
   }
-  private async jsonfySubjectResult(page: Page, rowElements: cheerio.Element[]): Promise<SubjectResult[]> {
-    const results: SubjectResult[] = [];
+  private async jsonfySubjectResult(
+    page: Page,
+    rowElements: cheerio.Element[]
+  ): Promise<SubjectResultUNB[]> {
+    const results: SubjectResultUNB[] = [];
     for (const rowElement of rowElements) {
-      if (page.$(rowElement).hasClass("agrupador")) {
+      if (page.$(rowElement).hasClass('agrupador')) {
         results.push(await this.parseSubjectSearchResults(page, rowElement));
-        
-      }
-      else if (page.$(rowElement).hasClass("linhaPar") || page.$(rowElement).hasClass("linhaImpar")){
-        results[results.length - 1].teams.push(await this.parseTeamsSearchResults(page, rowElement));
-      }
-      else {
-        continue;
-      }
-    }
-    return results;
-  }
-
-  private async objectfySubjectResult(page: Page, rowElements: cheerio.Element[]): Promise<SubjectResult[]> {
-    const results:SubjectResult[] = [];
-    for (const rowElement of rowElements) {
-      if (page.$(rowElement).hasClass("agrupador")) {
-        results.push(
-          new SigaaSearchSubjectResult(this.http, this.parser, await this.parseSubjectSearchResults(page, rowElement))
-        );
-      }
-      else if (page.$(rowElement).hasClass("linhaPar") || page.$(rowElement).hasClass("linhaImpar")){
+      } else if (
+        page.$(rowElement).hasClass('linhaPar') ||
+        page.$(rowElement).hasClass('linhaImpar')
+      ) {
         results[results.length - 1].teams.push(
-          new SigaaSearchTeamsResult(this.http, this.parser, await this.parseTeamsSearchResults(page, rowElement))
+          await this.parseTeamsSearchResults(page, rowElement)
         );
-      }
-      else {
+      } else {
         continue;
       }
     }
     return results;
   }
 
-  private async parseSearchResults(page: Page, in_json: boolean): Promise<SubjectResult[]> {
+  private async objectfySubjectResult(
+    page: Page,
+    rowElements: cheerio.Element[]
+  ): Promise<SubjectResultUNB[]> {
+    const results: SubjectResultUNB[] = [];
+    for (const rowElement of rowElements) {
+      if (page.$(rowElement).hasClass('agrupador')) {
+        results.push(
+          new SigaaSearchSubjectResultUNB(
+            this.http,
+            this.parser,
+            await this.parseSubjectSearchResults(page, rowElement)
+          )
+        );
+      } else if (
+        page.$(rowElement).hasClass('linhaPar') ||
+        page.$(rowElement).hasClass('linhaImpar')
+      ) {
+        results[results.length - 1].teams.push(
+          new SigaaSearchTeamsResultUNB(
+            this.http,
+            this.parser,
+            await this.parseTeamsSearchResults(page, rowElement)
+          )
+        );
+      } else {
+        continue;
+      }
+    }
+    return results;
+  }
+
+  private async parseSearchResults(
+    page: Page,
+    in_json: boolean
+  ): Promise<SubjectResultUNB[]> {
     const rowElements = page.$('table.listagem > tbody > tr[class]').toArray();
     if (in_json) {
       return this.jsonfySubjectResult(page, rowElements);

--- a/src/search/subject/UNB/sigaa-search-subject-result-UNB.ts
+++ b/src/search/subject/UNB/sigaa-search-subject-result-UNB.ts
@@ -1,0 +1,124 @@
+import { Parser } from '@helpers/sigaa-parser';
+import { HTTP } from '@session/sigaa-http';
+
+/**
+ * @category Internal
+ */
+export interface TeamsResultDataUNB {
+  id: number;
+  teacher: string;
+  schedule: string;
+  location: string;
+}
+
+/**
+ * @category Public
+ */
+export interface TeamsResultUNB {
+  readonly id: number;
+  readonly teacher: string;
+  readonly schedule: string;
+  readonly location: string;
+}
+
+/**
+ * @category Internal
+ */
+export interface SubjectResultDataUNB {
+  id: string;
+  name: string;
+  teams: TeamsResultDataUNB[];
+}
+
+/**
+ * @category Public
+ */
+export interface SubjectResultUNB {
+  readonly id: string;
+  readonly name: string;
+  readonly teams: TeamsResultUNB[];
+}
+
+/**
+ * @category Internal
+ */
+export class SigaaSearchTeamsResultUNB implements TeamsResultUNB {
+  private _id: number;
+  private _teacher: string;
+  private _schedule: string;
+  private _location: string;
+
+  constructor(
+    private _http: HTTP,
+    private _parser: Parser,
+    options: TeamsResultDataUNB
+  ) {
+    this._id = options.id;
+    this._teacher = options.teacher;
+    this._schedule = options.schedule;
+    this._location = options.location;
+  }
+
+  public get id(): number {
+    return this._id;
+  }
+
+  public get teacher(): string {
+    return this._teacher;
+  }
+
+  public get schedule(): string {
+    return this._schedule;
+  }
+
+  public get location(): string {
+    return this._location;
+  }
+
+  public get http(): HTTP {
+    return this._http;
+  }
+
+  public get parser(): Parser {
+    return this._parser;
+  }
+}
+
+/**
+ * @category Internal
+ */
+export class SigaaSearchSubjectResultUNB implements SubjectResultUNB {
+  private _id: string;
+  private _name: string;
+  private _teams: TeamsResultDataUNB[];
+
+  constructor(
+    private _http: HTTP,
+    private _parser: Parser,
+    options: SubjectResultDataUNB
+  ) {
+    this._id = options.id;
+    this._name = options.name;
+    this._teams = options.teams;
+  }
+
+  public get id(): string {
+    return this._id;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get teams(): TeamsResultUNB[] {
+    return this._teams;
+  }
+
+  public get http(): HTTP {
+    return this._http;
+  }
+
+  public get parser(): Parser {
+    return this._parser;
+  }
+}

--- a/src/session/sigaa-session.ts
+++ b/src/session/sigaa-session.ts
@@ -19,6 +19,8 @@ export interface Session {
  * @category Internal
  */
 export class SigaaSession implements Session {
-  constructor(public readonly institution: InstitutionType = 'IFSC') {}
+  constructor(public readonly institution: InstitutionType = 'IFSC') {
+    this.institution = institution.toUpperCase() as InstitutionType;
+  }
   loginStatus: LoginStatus = LoginStatus.Unauthenticated;
 }

--- a/src/sigaa-all-types.ts
+++ b/src/sigaa-all-types.ts
@@ -46,16 +46,17 @@ export * from '@resources/sigaa-file';
 export * from '@resources/sigaa-resource-manager';
 export * from '@resources/updatable-resource';
 
-
 export * from '@search/sigaa-common-structures';
 
-export * from '@search/subject/sigaa-search-subject-result';
-export * from '@search/subject/sigaa-search-subject';
+export * from '@search/subject/UNB/sigaa-search-subject-result-UNB';
+export * from '@search/subject/UNB/sigaa-search-subject-UNB';
+
+export * from '@search/subject/IFSC/sigaa-search-subject-result-IFSC';
+export * from '@search/subject/IFSC/sigaa-search-subject-IFSC';
 
 export * from '@search/teacher/sigaa-search-teacher-result';
 export * from '@search/teacher/sigaa-search-teacher';
 export * from '@search/sigaa-search';
-
 
 export * from '@session/login/sigaa-login-ifsc';
 export * from '@session/login/sigaa-login-ufpb';

--- a/src/sigaa-main.ts
+++ b/src/sigaa-main.ts
@@ -300,10 +300,9 @@ export class Sigaa {
       UNB: SigaaLoginUNB
     };
     const institution = options.institution ?? 'IFSC';
-    this.loginInstance = new SigaaLoginInstitution[institution](
-      this.http,
-      this.session
-    );
+    this.loginInstance = new SigaaLoginInstitution[
+      institution.toUpperCase() as InstitutionType
+    ](this.http, this.session);
   }
 
   /**
@@ -338,7 +337,7 @@ export class Sigaa {
    * Returns instance of SigaaSearch.
    */
   get search(): SigaaSearch {
-    return new SigaaSearch(this.http, this.parser);
+    return new SigaaSearch(this.http, this.parser, this.session);
   }
 
   /**

--- a/src/tests/search/subject.spec.ts
+++ b/src/tests/search/subject.spec.ts
@@ -1,4 +1,3 @@
-import { SigaaSearchSubject } from "@search/subject/sigaa-search-subject";
 import { Sigaa } from "src/sigaa-main";
 
 


### PR DESCRIPTION
A única incompatibilidade que eu encontrei, foi que no SIGAA do IFSC não tem a informação do horário da aula. Por isso precisei separar as classes da UnB e IFSC. 

Para selecionar a classe da instituição respectiva, fiz um "map" pelas classes criadas.
```ts
// src/search/sigaa-search.ts
subject(): SigaaSearchSubject {
    const institution = this.session.institution;
    const SigaaSearchSubject = {
      IFSC: SigaaSearchSubjectIFSC,
      UNB: SigaaSearchSubjectUNB,
      UFPB: SigaaSearchSubjectIFSC
    };
    return new SigaaSearchSubject[institution](this.http, this.parser);
  }
```
Uma das alterações feitas, tanto na UNB quanto no IFSC. 
No postValues da requisição de pesquisa. Esse j_id_jsp é gerado pelo servidor e acredito que possa mudar se houver alguma atualização.
```ts
postValues['formTurma:j_id_jsp_1370969402_11'] = 'Buscar';
```
Por isso, busquei o atributo "name" em algum input que tenha o value "Buscar". Assim o "name" do botão fica dinâmico.
```ts
// src/search/subject/UNB/sigaa-search-subject-UNB.ts
const searchButtonNameAttr = page.$('input[value="Buscar"]').attr('name');
    if (!searchButtonNameAttr)
      throw new Error('SIGAA: Search button not found.');

    postValues[searchButtonNameAttr] = 'Buscar';
```

Outra alteração interessante, no código da classe para o IFSC, na hora de pegar o valor das colunas, não gostei de pegar pela posição do `<tr>`.
Então, fiz ele pegar o texto das colunas e sua posição respectiva, assim consigo escolher a coluna para cada variável.
```ts
// src/search/subject/IFSC/sigaa-search-subject-IFSC.ts
for (let i = 0; i < rowHeaderElements.length; i++) {
      const columnHeader = page.$(rowHeaderElements[i]).text();
      const columnValue = page.$(rowElement).find('td').eq(i).text();
      switch (columnHeader) {
        case 'Código':
          id = Number.parseInt(columnValue);
          break;
        case 'Docente':
          teacher = columnValue;
          break;
        case 'Local':
          location = columnValue;
      }
    }
```
Outra mudança pequena foi na linha para dar split no titulo da disciplina.
```ts
// src/search/subject/UNB/sigaa-search-subject-UNB.ts
const id_name: string[] = this.parser
      .removeTagsHtml(page.$(rowElement).find('span.tituloDisciplina').html())
      .split(' - ');
```
Ao invés de dar `.split('-')`, que deixa sobrar espaços depois do id e antes do titulo, fica `.split(' - ')`.

Por fim, mudei o exemplo da feature.
```js
// examples/get-subjects.js
unb_fga_subjects.map(subject => {
      console.log(`\n${subject.id} - ${subject.name}`);
      console.log(`Turmas:`);
      subject.teams.map(team => {
        console.log(`  Código: ${team.id}`);
        console.log(`  Docente: ${team.teacher}`);
        console.log(`  Local: ${team.location}`);
        if (team.schedule) {
          console.log(`  Horário: ${team.schedule}`);
        }
        console.log(``);
      });
    })
```